### PR TITLE
fix: cleanup old icons correctly.

### DIFF
--- a/src/rescle.cc
+++ b/src/rescle.cc
@@ -902,7 +902,7 @@ BOOL CALLBACK ResourceUpdater::OnEnumResourceLanguage(HANDLE hModule, LPCWSTR lp
       }
       case reinterpret_cast<ptrdiff_t>(RT_ICON): {
         UINT iconId = reinterpret_cast<ptrdiff_t>(lpszName);
-        UINT maxIconId = instance->iconBundleMap_[wIDLanguage].maxIconId;
+        UINT& maxIconId = instance->iconBundleMap_[wIDLanguage].maxIconId;
         if (iconId > maxIconId)
           maxIconId = iconId;
         break;


### PR DESCRIPTION
This updates the correct field rather than assigning the new max icon ID
to a local variable. Previously, if you had set an icon with ten images
and then later set a new icon with only one image, nine old images would
linger in the executable. If you revised your icon over time and reduced
the number of images each time, old icons from multiple different passes
would linger in the executable.

This bug was introduced by af37f5f which landed after the fix to a
similar bug that was described in issue #27.